### PR TITLE
修正Global.h中宏定义以及增加ClickLabel部件

### DIFF
--- a/build/tianchi.pro
+++ b/build/tianchi.pro
@@ -1,89 +1,11 @@
-# ======================================================================================================================
+# ===========================================================================
 # Date          Qt / OS / Compiler              Name        Description
-# ----------------------------------------------------------------------------------------------------------------------
-# 2013.04.15    Qt5.0.1-x32 / Win8 / VC2010     Jonix       编译动态链接库(.dll/.lib)成功
-#               Qt5.0.2-x64 / Win8 / VC2012     Jonix       编译动态链接库(.dll/.lib)成功
+# ---------------------------------------------------------------------------
+# 2013.04.15    Qt5.0.1-x32 / Win8 / VC2010     Jonix       编译dll成功
+#               Qt5.0.2-x64 / Win8 / VC2012     Jonix       编译dll成功
 #
 #
 #
-# ======================================================================================================================
-QT += sql network script
-greaterThan(QT_MAJOR_VERSION, 4) { 
-    QT += widgets
-    win32:QT += axcontainer
-} else {
-    QT += gui
-    win32:CONFIG += qaxcontainer
-    DEFINES += QT_WIDGETS_LIB
-}
-
-DESTDIR = ../dll_lib
-TARGET = tianchi
-TEMPLATE = lib
-
-DEFINES += TIANCHI_EXPORT
-
-INCLUDEPATH += ../inc
-
-win32:!win32-g++{
-    LIBS += -lversion -ladvapi32 -lole32
-}
-
-HEADERS +=\
-    ../inc/Chinese/msime.h \
-    ../inc/Core/Classes.h \
-    ../inc/Core/Global.h \
-    ../inc/Core/Utils.h \
-    ../inc/File/Json.h \
-    ../inc/File/LogTiny.h \
-    ../inc/File/MSExcel.h \
-    ../inc/Gui/DateEdit.h \
-    ../inc/Gui/TreeWidgetHeaderSetupDialog.h \
-    ../inc/Chinese/Chinese.h \
-    ../inc/OS/OS.h \
-    ../inc/Global.h \
-    ../inc/Core/Common.h \
-    ../inc/Gui/GuiUtils.h \
-    ../inc/File/FileUtils.h \
-    ../inc/tianchi.h \
-    ../inc/Core/String.h
-
-SOURCES += \
-    ../src/Core/Classes.cpp \
-    ../src/Core/Utils.cpp \
-    ../src/File/Json.cpp \
-    ../src/File/LogTiny.cpp \
-    ../src/File/MSExcel.cpp \
-    ../src/Gui/DateEdit.cpp \
-    ../src/Gui/TreeWidgetHeaderSetupDialog.cpp \
-    ../src/OS/OS.cpp \
-    ../src/Chinese/Chinese.cpp \
-    ../src/Core/Common.cpp \
-    ../src/Gui/GuiUtils.cpp \
-    ../src/File/FileUtils.cpp \
-    ../src/Core/String.cpp
-
-FORMS += \
-    ../src/Gui/TreeWidgetHeaderSetupDialog.ui
-
-RESOURCES += \
-    ../res/tianchi.qrc
-
-#symbian {
-#    MMP_RULES += EXPORTUNFROZEN
-#    TARGET.UID3 = 0xEEA5DB7F
-#    TARGET.CAPABILITY =
-#    TARGET.EPOCALLOWDLLDATA = 1
-#    addFiles.sources = TianChi.dll
-#    addFiles.path = !:/sys/bin
-#    DEPLOYMENT += addFiles
-#}
-
-#unix:!symbian {
-#    maemo5 {
-#        target.path = /opt/usr/lib
-#    } else {
-#        target.path = /usr/lib
-#    }
-#    INSTALLS += target
-#}
+# ===========================================================================
+CONFIG += shared
+include($$PWD/../src/src.pri)

--- a/build/tianchi_s.pro
+++ b/build/tianchi_s.pro
@@ -1,92 +1,11 @@
-# ======================================================================================================================
+# ===========================================================================
 # Date          Qt / OS / Compiler              Name        Description
-# ----------------------------------------------------------------------------------------------------------------------
-# 2013.04.15    Qt5.0.1-x32 / Win8 / VC2010     Jonix       编译静态链接库(.lib)成功
-#               Qt5.0.2-x64 / Win8 / VC2012     Jonix       编译静态链接库(.lib)成功
+# ---------------------------------------------------------------------------
+# 2013.04.15    Qt5.0.1-x32 / Win8 / VC2010     Jonix       编译staticlib成功
+#               Qt5.0.2-x64 / Win8 / VC2012     Jonix       编译staticlib成功
 #
 #
 #
-# ======================================================================================================================
-QT += sql network script
-greaterThan(QT_MAJOR_VERSION, 4) { 
-    QT += widgets
-    win32:QT += axcontainer
-} else {
-    QT += gui
-    win32:CONFIG += qaxcontainer
-    DEFINES += QT_WIDGETS_LIB
-}
-
-DESTDIR = ../staticlib
-TARGET = tianchi
-TEMPLATE = lib
-
-# 生成静态链接库
+# ===========================================================================
 CONFIG += staticlib
-
-DEFINES -= TIANCHI_EXPORT TIANCHI_IMPORT
-
-INCLUDEPATH += ../inc
-
-win32:!win32-g++{
-    LIBS += -lversion -ladvapi32 -lole32
-}
-
-HEADERS +=\
-    ../inc/Chinese/msime.h \
-    ../inc/Core/Classes.h \
-    ../inc/Core/Global.h \
-    ../inc/Core/Utils.h \
-    ../inc/File/Json.h \
-    ../inc/File/LogTiny.h \
-    ../inc/File/MSExcel.h \
-    ../inc/Gui/DateEdit.h \
-    ../inc/Gui/TreeWidgetHeaderSetupDialog.h \
-    ../inc/Chinese/Chinese.h \
-    ../inc/OS/OS.h \
-    ../inc/Global.h \
-    ../inc/Core/Common.h \
-    ../inc/Gui/GuiUtils.h \
-    ../inc/File/FileUtils.h \
-    ../inc/tianchi.h \
-    ../inc/Core/String.h
-
-SOURCES += \
-    ../src/Core/Classes.cpp \
-    ../src/Core/Utils.cpp \
-    ../src/File/Json.cpp \
-    ../src/File/LogTiny.cpp \
-    ../src/File/MSExcel.cpp \
-    ../src/Gui/DateEdit.cpp \
-    ../src/Gui/TreeWidgetHeaderSetupDialog.cpp \
-    ../src/OS/OS.cpp \
-    ../src/Chinese/Chinese.cpp \
-    ../src/Core/Common.cpp \
-    ../src/Gui/GuiUtils.cpp \
-    ../src/File/FileUtils.cpp \
-    ../src/Core/String.cpp
-
-FORMS += \
-    ../src/Gui/TreeWidgetHeaderSetupDialog.ui
-
-RESOURCES += \
-    ../res/tianchi.qrc
-
-#symbian {
-#    MMP_RULES += EXPORTUNFROZEN
-#    TARGET.UID3 = 0xEEA5DB7F
-#    TARGET.CAPABILITY =
-#    TARGET.EPOCALLOWDLLDATA = 1
-#    addFiles.sources = TianChi.dll
-#    addFiles.path = !:/sys/bin
-#    DEPLOYMENT += addFiles
-#}
-
-#unix:!symbian {
-#    maemo5 {
-#        target.path = /opt/usr/lib
-#    } else {
-#        target.path = /usr/lib
-#    }
-#    INSTALLS += target
-#}
+include($$PWD/../src/src.pri)

--- a/inc/Core/Classes.h
+++ b/inc/Core/Classes.h
@@ -27,6 +27,8 @@
 
 TIANCHI_BEGIN_NAMESPACE
 
+QT_USE_NAMESPACE
+
 /// @brief 玩家信息类，常用在 C/S 中的客户端用户信息保存
 class TIANCHI_API Player : public QObject
 {

--- a/inc/Core/Common.h
+++ b/inc/Core/Common.h
@@ -82,7 +82,9 @@ inline void MsgBox(const QString& s)
 /// @param [in] text 显示文本内容
 inline void debug_out(const char* file, int line, const QString& text="")
 {
+#if defined(QT_DEBUG)
     cout<<QDateTime::currentDateTime().toString("yyyy/MM/dd HH:mm:ss->").toLocal8Bit().data()<<file<<"("<<line<<"): "<<text.toLocal8Bit().data()<<endl;
+#endif // defined(QT_DEBUG)
 }
 /// @brief 调试信息快速显示类
 /// @param [in] file 源文件名

--- a/inc/Global.h
+++ b/inc/Global.h
@@ -13,23 +13,14 @@
 // 2013.04.17   XChinux     参照Qt/qglobal.h文件重写Global.h
 // ==========================================================================
 // 注意事项:
-// 1. 编译Tianchi共享库或Tianchi静态库时请在 .pro 中添加：
-//      DEFINES += TIANCHI_BUILD_LIB
-// 2. 如果编译Tianchi库时要自定义名字空间,则在.pro中添加:
-//      DEFINES += TIANCHI_NAMESPACE=mynamespace
-//    如未定义TIANCHI_NAMESPACE,则默认定义为Tianchi
-// 3. TIANCHI_EXPORT与TIANCHI_API同义
-// 4. 如果要编译Tianchi静态库,则在.pro中添加:
-//      DEFINES += TIANCHI_STATIC
-// 5. 如果用户要直接使用源代码,请定义TIANCHI_USE_SOURCE宏
+// 1. 编译Tianchi DLL时请在 .pro 中添加：
+//      DEFINES += TIANCHI_EXPORT
+// 2. 使用Tianchi DLL时请在.pro中添加
+//      DEFINES += TIANCHI_IMPORT
 // ==========================================================================
 
 #ifndef TIANCHI_GLOBAL_H
 #define TIANCHI_GLOBAL_H
-
-#ifndef __cplusplus
-#    error "Tianchi library only support C++ Compilers"
-#endif
 
 
 /**
@@ -41,6 +32,10 @@
 
 
 #include <QtCore/qglobal.h>
+
+#ifndef __cplusplus
+#    error "Tianchi library only support C++ Compilers"
+#endif
 
 
 #define TIANCHI_VERSION_STR   "0.0.1"
@@ -75,36 +70,13 @@ namespace TIANCHI_NAMESPACE {}
 #define TIANCHI_BEGIN_HEADER
 #define TIANCHI_END_HEADER
 
-TIANCHI_BEGIN_HEADER
-TIANCHI_BEGIN_NAMESPACE
-
-#if defined(TIANCHI_USE_SOURCE)
-#  if defined(TIANCHI_SHARED) || defined(TIANCHI_STATIC)
-#    error "Both TIANCHI_USE_SOURCE and TIANCHI_SHARED/TIANCHI_STATIC defined conflicted"
-#  endif
-#  define TIANCHI_EXPORT
-#elif defined(TIANCHI_SHARED) || !defined(TIANCHI_STATIC)
-#  ifdef TIANCHI_STATIC
-#    error "Both TIANCHI_SHARED and TIANCHI_STATIC defined conflicted"
-#  endif
-#  ifndef TIANCHI_SHARED
-#    define TIANCHI_SHARED
-#  endif
-#  if defined(TIANCHI_BUILD_LIB)
-#    define TIANCHI_EXPORT Q_DECL_EXPORT
-#  else
-#    define TIANCHI_EXPORT Q_DECL_IMPORT
-#  endif
+#if defined(TIANCHI_EXPORT)
+#  define TIANCHI_API Q_DECL_EXPORT
+#elif defined(TIANCHI_IMPORT)
+#  define TIANCHI_API Q_DECL_IMPORT
 #else
-#  define TIANCHI_EXPORT
+#  define TIANCHI_API
 #endif
 
-TIANCHI_EXPORT const char *tianchiVersion() Q_DECL_NOTHROW;
-TIANCHI_EXPORT bool tianchiSharedBuild() Q_DECL_NOTHROW;
-
-TIANCHI_END_NAMESPACE
-TIANCHI_END_HEADER
-
-#define TIANCHI_API TIANCHI_EXPORT
 
 #endif // TIANCHI_GLOBAL_H

--- a/inc/Gui/ClickLabel.h
+++ b/inc/Gui/ClickLabel.h
@@ -1,0 +1,58 @@
+// **************************************************************************
+// Tianchi share library for Qt (C++)
+// 天池共享源码库
+// 版权所有 (C) 天池共享源码库开发组
+// 授权协议：请阅读天池共享源码库附带的授权协议
+// **************************************************************************
+// 文档说明：可发出clicked信号的Label部件
+// ==========================================================================
+// 开发日志：
+// 日期         人员        说明
+// --------------------------------------------------------------------------
+// 2013.04.17   XChinux     建立
+//
+// ==========================================================================
+/// @file ClickLabel.h 可发出clicked信号的Label部件
+// ==========================================================================
+#ifndef TIANCHI_CLICKLABEL_H
+#define TIANCHI_CLICKLABEL_H
+
+#include <Global.h>
+#include <QLabel>
+
+TIANCHI_BEGIN_HEADER
+
+TIANCHI_BEGIN_NAMESPACE
+
+
+QT_USE_NAMESPACE
+
+class ClickLabelPrivate;
+
+
+/// @brief 可发出clicked信号的Label部件
+class TIANCHI_API ClickLabel : public QLabel
+{
+    Q_OBJECT
+public:
+    ClickLabel(QWidget *parent = 0, Qt::WindowFlags f = 0);
+    ClickLabel(const QString &text, QWidget *parent = 0, 
+            Qt::WindowFlags f = 0);
+    ~ClickLabel();
+Q_SIGNALS:
+    /// @brief 点击部件时发出clicked信号
+    void clicked();
+protected:
+    virtual void mousePressEvent(QMouseEvent *e);
+    virtual void mouseReleaseEvent(QMouseEvent *e);
+private:
+    Q_DISABLE_COPY(ClickLabel)
+    Q_DECLARE_PRIVATE(ClickLabel)
+    ClickLabelPrivate *d_ptr;
+};
+
+TIANCHI_END_NAMESPACE
+
+TIANCHI_END_HEADER
+
+#endif

--- a/src/Core/Classes.cpp
+++ b/src/Core/Classes.cpp
@@ -3,6 +3,8 @@
 
 TIANCHI_BEGIN_NAMESPACE
 
+QT_USE_NAMESPACE
+
 Player::Player()
     : QObject()
 {
@@ -159,5 +161,7 @@ QHash<QString, QByteArray> DBFields::getFields(const QByteArray& fieldBytes)
     }
     return ret;
 }
+
+#include "moc_Classes.cpp"
 
 TIANCHI_END_NAMESPACE

--- a/src/Gui/ClickLabel.cpp
+++ b/src/Gui/ClickLabel.cpp
@@ -1,0 +1,69 @@
+#include <Gui/ClickLabel.h>
+#include <QPoint>
+#include <QMouseEvent>
+
+TIANCHI_BEGIN_NAMESPACE
+
+QT_USE_NAMESPACE
+
+class ClickLabelPrivate
+{
+    Q_DECLARE_PUBLIC(ClickLabel)
+public:
+    explicit ClickLabelPrivate(ClickLabel *qptr);
+    ~ClickLabelPrivate();
+    QPoint pos;
+    ClickLabel *q_ptr;
+};
+
+ClickLabelPrivate::ClickLabelPrivate(ClickLabel *qptr) : q_ptr(qptr)
+{
+}
+
+ClickLabelPrivate::~ClickLabelPrivate()
+{
+}
+
+ClickLabel::ClickLabel(QWidget *parent, Qt::WindowFlags f)
+    : QLabel(parent, f), d_ptr(new ClickLabelPrivate(this))
+{
+}
+
+ClickLabel::ClickLabel(const QString &text, QWidget *parent, Qt::WindowFlags f)
+    : QLabel(text, parent, f), d_ptr(new ClickLabelPrivate(this))
+{
+}
+
+ClickLabel::~ClickLabel()
+{
+    delete d_ptr;
+}
+
+void ClickLabel::mousePressEvent(QMouseEvent *e)
+{
+    QLabel::mousePressEvent(e);
+
+    Q_D(ClickLabel);
+    if (e->button() == Qt::LeftButton)
+    {
+        d->pos = e->pos();
+    }
+}
+
+void ClickLabel::mouseReleaseEvent(QMouseEvent *e)
+{
+    QLabel::mouseReleaseEvent(e);
+
+    Q_D(ClickLabel);
+    if (e->button() == Qt::LeftButton)
+    {
+        if (e->pos() == d->pos)
+        {
+            emit clicked();
+        }
+    }
+}
+
+#include "moc_ClickLabel.cpp"
+
+TIANCHI_END_NAMESPACE

--- a/src/Gui/DateEdit.cpp
+++ b/src/Gui/DateEdit.cpp
@@ -82,4 +82,7 @@ void DateEdit::unsetDate()
     setEditText("");
 }
 
+
+#include "moc_DateEdit.cpp"
+
 TIANCHI_END_NAMESPACE

--- a/src/Gui/TreeWidgetHeaderSetupDialog.cpp
+++ b/src/Gui/TreeWidgetHeaderSetupDialog.cpp
@@ -110,4 +110,6 @@ void TreeWidgetHeaderSetupDialog::on_bnRight_clicked()
     }
 }
 
+#include "moc_TreeWidgetHeaderSetupDialog.cpp"
+
 TIANCHI_END_NAMESPACE

--- a/src/src.pri
+++ b/src/src.pri
@@ -1,0 +1,89 @@
+# ===========================================================================
+# Date          Qt / OS / Compiler              Name        Description
+# ---------------------------------------------------------------------------
+# 2013.04.15    Qt5.0.1-x32 / Win8 / VC2010     Jonix       编译(dll/lib)成功
+#               Qt5.0.2-x64 / Win8 / VC2012     Jonix       编译(dll/lib)成功
+#
+#
+#
+# ===========================================================================
+
+TEMPLATE = lib
+TARGET = tianchi
+QT += sql network script
+greaterThan(QT_MAJOR_VERSION, 4) { 
+    QT += gui widgets
+    win32:QT += axcontainer
+} else {
+    QT += gui
+    win32:CONFIG += qaxcontainer
+    DEFINES += QT_WIDGETS_LIB
+}
+
+TC_TMP = $$PWD/../tmp
+
+CONFIG(debug, debug|release) {
+    TARGET = $${TARGET}d
+    TC_TMP = $${TC_TMP}/debug
+} else {
+    TC_TMP = $${TC_TMP}/release
+}
+
+CONFIG(static, static|shared) | CONFIG(staticlib, staticlib|shared) {
+    DESTDIR = $$PWD/../dll_lib
+    TARGET = $${TARGET}_s
+} else { 
+    DESTDIR = $$PWD/../dll_lib
+    DEFINES += TIANCHI_EXPORT
+}
+
+MOC_DIR = $$TC_TMP
+OBJECTS_DIR = $$TC_TMP
+UI_HEADERS_DIR = $$TC_TMP
+RCC_DIR = $$TC_TMP
+
+TC_INCL = $$PWD/../inc
+
+INCLUDEPATH += $$TC_INCL
+
+win32:!win32-g++{
+    LIBS += -lversion -ladvapi32 -lole32
+}
+
+HEADERS += \
+    $$TC_INCL/Global.h \
+    $$TC_INCL/tianchi.h \
+    $$TC_INCL/Chinese/Chinese.h \
+    $$TC_INCL/Core/Classes.h \
+    $$TC_INCL/Core/Common.h \
+    $$TC_INCL/Core/String.h \
+    $$TC_INCL/Core/Utils.h \
+    $$TC_INCL/File/Json.h \
+    $$TC_INCL/File/LogTiny.h \
+    $$TC_INCL/File/MSExcel.h \
+    $$TC_INCL/File/FileUtils.h \
+    $$TC_INCL/Gui/ClickLabel.h \
+    $$TC_INCL/Gui/DateEdit.h \
+    $$TC_INCL/Gui/GuiUtils.h \
+    $$TC_INCL/Gui/TreeWidgetHeaderSetupDialog.h \
+    $$TC_INCL/OS/OS.h
+SOURCES += \
+    $$PWD/Chinese/Chinese.cpp \
+    $$PWD/Core/Classes.cpp \
+    $$PWD/Core/Utils.cpp \
+    $$PWD/Core/Common.cpp \
+    $$PWD/Core/String.cpp \
+    $$PWD/File/Json.cpp \
+    $$PWD/File/LogTiny.cpp \
+    $$PWD/File/MSExcel.cpp \
+    $$PWD/File/FileUtils.cpp \
+    $$PWD/Gui/ClickLabel.cpp \
+    $$PWD/Gui/DateEdit.cpp \
+    $$PWD/Gui/TreeWidgetHeaderSetupDialog.cpp \
+    $$PWD/Gui/GuiUtils.cpp \
+    $$PWD/OS/OS.cpp
+FORMS += \
+    $$PWD/Gui/TreeWidgetHeaderSetupDialog.ui
+
+RESOURCES += \
+    $$PWD/../res/tianchi.qrc


### PR DESCRIPTION
1. 添加ClickLabel部件 …
2. 修正Global.h中的宏定义,去除TIANCHI_SHARED、TIANCHI_STATIC、TIANCHI_BUILD_LIB，增加TIANCHI_EXPORT和TIANCHI_IMPORT
3. 增加src/src.pri，集中管理所有内容, build目录下只做差异化处理
4. 在定义过Q_OBJECT的头件对应的CPP File中增加#include
   "moc_xxxx.cpp"以兼容Qt4
